### PR TITLE
kwangkim improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Stream your DGX Spark desktop at high quality (up to 1440p @ 120Hz or 4K @ 60Hz)
 
 ### Display Resolutions
 - **4K @ 60Hz** (3840x2160) - Maximum resolution, lower refresh rate
+- **Ultrawide @ 60Hz** (3440x1440) - Dell AW3420DW and similar 21:9 monitors
+- **iPad Pro 12.9 @ 60Hz** (2732x2048) - Native iPad Pro M2 resolution via Tailscale
 - **1440p @ 120Hz** (2560x1440) - **Recommended** - Best balance of quality and smoothness
 - **1080p @ 120Hz** (1920x1080) - Lower resolution, maximum smoothness
 
@@ -37,6 +39,8 @@ The GB10's unified memory architecture has a **165 MHz pixel clock limitation**,
 
 **What Works**:
 - ✅ 4K @ 60Hz
+- ✅ 3440x1440 @ 60Hz (Ultrawide)
+- ✅ 2732x2048 @ 60Hz (iPad Pro 12.9)
 - ✅ 1440p @ 120Hz
 - ✅ 1080p @ 120Hz
 
@@ -47,7 +51,7 @@ The GB10's unified memory architecture has a **165 MHz pixel clock limitation**,
 
 ### Required
 - **Hardware**: NVIDIA DGX Spark with GB10 GPU
-- **OS**: Ubuntu 24.04 (or similar Debian-based distribution)
+- **OS**: Ubuntu 24.04.3 LTS (DGX OS 7.3.1 or newer)
 - **NVIDIA Driver**: Version 580.95.05 or newer
 - **Desktop Environment**: X11-based (GDM, GNOME, etc.)
 - **Auto-login**: Configured for your user account (required for headless operation)
@@ -204,6 +208,29 @@ journalctl --user -u sunshine -f
 # Verify environment variables
 systemctl --user show sunshine -p Environment
 ```
+
+### Sunshine Not Starting Automatically After Reboot
+
+**Problem**: Sunshine doesn't start automatically after system reboot, only after GUI login
+
+**Cause**: Systemd user services require either a user session or "lingering" to start at boot.
+
+**Solutions**:
+```bash
+# Enable session lingering for your user (allows services to start at boot)
+loginctl enable-linger $(whoami)
+
+# Verify lingering is enabled
+loginctl show-user $(whoami) --property=Linger
+
+# Re-enable Sunshine auto-start
+systemctl --user enable sunshine
+
+# Reboot and verify
+sudo reboot
+```
+
+**Note**: The installer now enables lingering automatically when you choose auto-start.
 
 ### Connection Issues
 

--- a/after-install.sh
+++ b/after-install.sh
@@ -132,6 +132,17 @@ check_sunshine_service() {
         log_success "Sunshine service is enabled for auto-start"
     fi
 
+    # Check session lingering status (required for reliable auto-start)
+    local linger_status
+    linger_status=$(loginctl show-user "$(whoami)" --property=Linger 2>/dev/null | cut -d= -f2)
+    if [[ "$linger_status" == "yes" ]]; then
+        log_success "Session lingering enabled (Sunshine can start at boot)"
+    else
+        log_warning "Session lingering not enabled"
+        echo -e "${GRAY}  Sunshine may not start until GUI login${RESET}"
+        echo -e "${GRAY}  To enable: ${DIM}loginctl enable-linger $(whoami)${RESET}"
+    fi
+
     echo ""
 
     if systemctl --user is-active sunshine &> /dev/null; then

--- a/goal.md
+++ b/goal.md
@@ -1,0 +1,52 @@
+Update dgx-spark-sunshine-setup to use the latest version of sunshine and fix the issue of sunshine not starting automatically.
+
+1. I will use ipad to connect to the dgx server via tailscale. Add ipad 12.9 pro M2 resolution to the sunshine config.
+2. Update all. DGX spark uses the latest version, Ubuntu 24.04.3 LTS and DGX OS 7.3.1.
+3. Install sunshine using the latest version from the official website.
+4. Fix the issue of sunshine not starting automatically.
+5. Add the current monitor DEll AW3420DW to the sunshine config.
+
+## Fixes Applied
+
+### Fix 1: GPU BusID Detection
+The script was looking for "nvidia.*gb10" in lspci output, but the GPU shows up as `Device 2e12` (not GB10). Now it correctly detects the NVIDIA VGA controller and properly converts the bus ID from hex (`000f:01:00.0`) to decimal (`PCI:1:0:0`).
+
+### Fix 2: Missing systemd Service File
+Newer Sunshine versions (2025.924+) don't ship with a systemd service file. Created `templates/sunshine.service` and updated the installer to copy it to `~/.config/systemd/user/`.
+
+### Fix 3: Use Ubuntu 24.04 ARM64 Package
+The installer was downloading `sunshine-debian-trixie-arm64.deb` which has incompatible library versions (needs `libminiupnpc.so.18` and `libicuuc.so.76`). Updated to download `sunshine-ubuntu-24.04-arm64.deb` instead.
+
+### Fix 4: Enable X11 and Auto-Login for Headless Operation
+Sunshine requires an X11 graphical session to detect displays and encode video. DGX OS defaults to Wayland which is not supported.
+
+**Applied changes to `/etc/gdm3/custom.conf`:**
+```ini
+[daemon]
+AutomaticLoginEnable=true
+AutomaticLogin=devkwang
+WaylandEnable=false
+```
+
+This enables:
+- **WaylandEnable=false** - Forces X11 instead of Wayland (required for Sunshine)
+- **AutomaticLogin** - Auto-logs into desktop on boot (required for headless streaming)
+
+### Fix 5: X11 Display Connector Name
+The xorg.conf was configured for `DFP-0` connector, but `nvidia-xconfig --query-gpu-info` shows the GB10 GPU uses `TV-0` as the display device name.
+
+**Changed in `/etc/X11/xorg.conf` and `templates/xorg.conf.template`:**
+```
+Option "ConnectedMonitor" "TV-0"
+Option "CustomEDID" "TV-0:/etc/X11/4k120.edid"
+```
+
+## Installation Steps
+
+1. Run installer: `./install.sh`
+2. Configure GDM for X11 and auto-login (see Fix 4 above)
+3. Reboot: `sudo reboot`
+4. Open firewall: `sudo ufw allow 47984:47990/tcp && sudo ufw allow 47998:48010/udp`
+5. Start Sunshine: `systemctl --user start sunshine`
+6. Configure credentials: Open https://192.168.2.200:47990 in browser
+7. Connect with Moonlight on iPad

--- a/install.sh
+++ b/install.sh
@@ -182,13 +182,15 @@ configure_resolution() {
     echo ""
     echo -e "${WHITE}${BOLD}Available Resolutions:${RESET}"
     echo -e "${GRAY}  1)${RESET} 3840x2160 @ 60Hz  ${DIM}(4K, lower refresh rate)${RESET}"
-    echo -e "${GRAY}  2)${RESET} 2560x1440 @ 120Hz ${DIM}(1440p, higher refresh rate)${RESET} ${NVIDIA_GREEN}[Recommended]${RESET}"
-    echo -e "${GRAY}  3)${RESET} 1920x1080 @ 120Hz ${DIM}(1080p, higher refresh rate)${RESET}"
+    echo -e "${GRAY}  2)${RESET} 3440x1440 @ 60Hz  ${DIM}(Dell AW3420DW Ultrawide 21:9)${RESET}"
+    echo -e "${GRAY}  3)${RESET} 2732x2048 @ 60Hz  ${DIM}(iPad Pro 12.9 M2)${RESET}"
+    echo -e "${GRAY}  4)${RESET} 2560x1440 @ 120Hz ${DIM}(1440p, higher refresh rate)${RESET} ${NVIDIA_GREEN}[Recommended]${RESET}"
+    echo -e "${GRAY}  5)${RESET} 1920x1080 @ 120Hz ${DIM}(1080p, higher refresh rate)${RESET}"
     echo ""
 
     local choice
     while true; do
-        prompt_user "Select resolution (1-3)" choice
+        prompt_user "Select resolution (1-5)" choice
         case "${choice}" in
             1)
                 RESOLUTION="3840x2160"
@@ -196,17 +198,27 @@ configure_resolution() {
                 break
                 ;;
             2)
+                RESOLUTION="3440x1440"
+                REFRESH_RATE="60"
+                break
+                ;;
+            3)
+                RESOLUTION="2732x2048"
+                REFRESH_RATE="60"
+                break
+                ;;
+            4)
                 RESOLUTION="2560x1440"
                 REFRESH_RATE="120"
                 break
                 ;;
-            3)
+            5)
                 RESOLUTION="1920x1080"
                 REFRESH_RATE="120"
                 break
                 ;;
             *)
-                log_error "Invalid selection. Please choose 1-3."
+                log_error "Invalid selection. Please choose 1-5."
                 ;;
         esac
     done
@@ -402,10 +414,16 @@ install_sunshine() {
     release_info=$(curl -sL "${SUNSHINE_RELEASE_URL}")
 
     local download_url
-    download_url=$(echo "${release_info}" | grep -o "https://.*sunshine.*arm64\.deb" | head -1)
+    # Specifically get Ubuntu 24.04 ARM64 package (not Debian Trixie which has library version mismatches)
+    download_url=$(echo "${release_info}" | grep -o "https://[^\"]*sunshine-ubuntu-24\.04-arm64\.deb" | head -1)
+    
+    # Fallback to any Ubuntu ARM64 package
+    if [[ -z "${download_url}" ]]; then
+        download_url=$(echo "${release_info}" | grep -o "https://[^\"]*sunshine-ubuntu.*arm64\.deb" | head -1)
+    fi
 
     if [[ -z "${download_url}" ]]; then
-        log_error "Failed to find ARM64 .deb package in latest release"
+        log_error "Failed to find Ubuntu ARM64 .deb package in latest release"
         exit 1
     fi
 
@@ -467,16 +485,36 @@ configure_x11() {
     # Detect GPU BusID
     log_substep "Detecting NVIDIA GPU BusID..."
     local bus_id
-    bus_id=$(lspci | grep -i "nvidia.*gb10" | awk '{print $1}')
+    # First try to find VGA controller from NVIDIA
+    bus_id=$(lspci | grep -i "VGA compatible controller: NVIDIA" | awk '{print $1}')
+    
+    # Fallback: try to find any NVIDIA GPU-like device
+    if [[ -z "${bus_id}" ]]; then
+        bus_id=$(lspci | grep -i "nvidia.*gb10" | awk '{print $1}')
+    fi
 
     if [[ -z "${bus_id}" ]]; then
-        log_error "Failed to detect GB10 GPU BusID"
+        log_error "Failed to detect NVIDIA GPU BusID"
+        log_substep "Please check 'lspci | grep -i nvidia' output"
         exit 1
     fi
 
-    # Convert from domain:bus:device.function to PCI:domain@bus:device:function
-    local pci_bus_id="PCI:${bus_id//:/@}"
-    pci_bus_id="PCI:${pci_bus_id//./:}"
+    # Convert from domain:bus:device.function to PCI:bus:device:function format
+    # lspci shows: 000f:01:00.0 -> we need: PCI:15:1:0
+    # Extract components
+    local domain bus device func
+    domain=$(echo "${bus_id}" | cut -d: -f1)
+    bus=$(echo "${bus_id}" | cut -d: -f2)
+    device=$(echo "${bus_id}" | cut -d: -f3 | cut -d. -f1)
+    func=$(echo "${bus_id}" | cut -d. -f2)
+    
+    # Convert hex to decimal
+    domain=$((16#${domain}))
+    bus=$((16#${bus}))
+    device=$((16#${device}))
+    func=$((10#${func}))
+    
+    local pci_bus_id="PCI:${bus}:${device}:${func}"
 
     log_success "Detected BusID: ${pci_bus_id}"
 
@@ -494,6 +532,28 @@ configure_x11() {
 
     log_success "X11 configuration installed"
     log_warning "X11 restart required - display will be reconfigured on next login"
+    log_complete
+}
+
+# ============================================================================
+# Permissions Configuration
+# ============================================================================
+configure_permissions() {
+    log_step "Configuring Permissions"
+
+    log_substep "Adding current user to 'video' and 'input' groups..."
+    sudo usermod -aG video,input "${USER}"
+    log_success "User added to groups"
+
+    log_substep "Configuring udev rules for uinput..."
+    local udev_rule='KERNEL=="uinput", SUBSYSTEM=="misc", OPTIONS+="static_node=uinput", TAG+="uaccess"'
+    echo "${udev_rule}" | sudo tee /etc/udev/rules.d/85-sunshine.rules > /dev/null
+    
+    log_substep "Reloading udev rules..."
+    sudo udevadm control --reload-rules
+    sudo udevadm trigger
+    log_success "udev rules configured"
+
     log_complete
 }
 
@@ -517,7 +577,16 @@ configure_sunshine() {
 
     # Configure systemd user service
     log_substep "Configuring systemd user service..."
+    mkdir -p "${SYSTEMD_USER_DIR}"
     mkdir -p "${SYSTEMD_USER_DIR}/sunshine.service.d"
+    
+    # Install the base service file (newer Sunshine versions don't include one)
+    if [[ ! -f "${SYSTEMD_USER_DIR}/sunshine.service" ]]; then
+        log_substep "Installing sunshine.service..."
+        cp "${TEMPLATES_DIR}/sunshine.service" "${SYSTEMD_USER_DIR}/sunshine.service"
+    fi
+    
+    # Install the override configuration
     cp "${TEMPLATES_DIR}/sunshine-override.conf" "${SYSTEMD_USER_DIR}/sunshine.service.d/override.conf"
 
     # Reload systemd
@@ -530,6 +599,16 @@ configure_sunshine() {
     if confirm "Enable Sunshine to start automatically on login?"; then
         systemctl --user enable sunshine
         log_success "Sunshine service enabled (will start automatically on next login)"
+        
+        # Enable lingering for user session persistence
+        # This allows the user's systemd services to start at boot, even before GUI login
+        log_substep "Enabling session persistence (lingering)..."
+        if loginctl enable-linger "$(whoami)" 2>/dev/null; then
+            log_success "Session lingering enabled for reliable auto-start"
+        else
+            log_warning "Could not enable lingering - Sunshine may not start until first login"
+            log_substep "To enable manually: ${DIM}loginctl enable-linger $(whoami)${RESET}"
+        fi
     else
         log_info "Sunshine service configured but not enabled for auto-start"
         log_substep "To start manually: ${DIM}systemctl --user start sunshine${RESET}"
@@ -675,6 +754,7 @@ main() {
     install_sunshine
     install_edid
     configure_x11
+    configure_permissions
     configure_sunshine
     validate_installation
 

--- a/setup.md
+++ b/setup.md
@@ -1,0 +1,62 @@
+# Setting up Moonlight on iPad with Sunshine
+
+This guide explains how to connect your iPad to the Sunshine streaming server running on your DGX Spark system.
+
+## Prerequisites
+
+1.  **Sunshine Running**: Ensure Sunshine is installed and running on your DGX Spark system.
+    *   Verify by accessing the Web UI at `https://<YOUR_DGX_IP>:47990`.
+2.  **Network**: Your iPad and DGX Spark must be on the same network, or accessible via VPN/ZeroTier/Tailscale.
+
+## Step 1: Install Moonlight on iPad
+
+1.  Open the **App Store** on your iPad.
+2.  Search for **Moonlight Game Streaming**.
+3.  Install the app (developed by Cameron Gutman).
+
+## Step 2: Pair iPad with Sunshine
+
+1.  Open **Moonlight** on your iPad.
+2.  Wait for your DGX Spark PC to appear in the PC list.
+    *   If it doesn't appear automatically, tap the **+** icon in the top right and enter your DGX Spark's IP address manually.
+3.  Tap on your PC icon.
+4.  A 4-digit PIN will appear on your iPad screen.
+5.  Go to your computer (or access the Sunshine Web UI from your iPad browser) at `https://<YOUR_DGX_IP>:47990`.
+6.  Navigate to the **PIN** tab in the top menu.
+7.  Enter the 4-digit PIN displayed on your iPad and click **Send**.
+8.  Your iPad should now be paired.
+
+## Step 3: Configure Resolution & Settings
+
+To get the best experience on iPad Pro 12.9" (or other models), you should match the streaming resolution to your device aspect ratio or the native resolutions we configured.
+
+1.  In Moonlight on iPad, tap the **Settings** (gear icon).
+2.  **Resolution**:
+    *   For **iPad Pro 12.9"**, select **Native (2732x2048)** if available, or manually set a custom resolution if the option allows.
+    *   If using the pre-configured dummy display modes from our `install.sh`, you can select **4K (3840x2160)** for high quality, or **1440p (2560x1440)** for better performance, depending on your bandwidth.
+    *   *Note: Our setup script includes a custom mode for 2732x2048 to match the iPad Pro 12.9" aspect ratio perfectly.*
+3.  **Frame Rate**: Set to **60 FPS** or **120 FPS** (if your iPad supports ProMotion and your network can handle it).
+4.  **Bitrate**:
+    *   Adjust based on your connection. **50-80 Mbps** is usually a good sweet spot for local Wi-Fi 5/6 connections.
+5.  **Touchscreen Mode**:
+    *   Moonlight supports different input modes. For desktop use, "Trackpad" mode might be useful, or use a Bluetooth mouse/keyboard paired to the iPad.
+
+## Step 4: Connecting
+
+1.  Tap your PC icon in the main Moonlight list.
+2.  Select **Desktop** (or the specific application you want to launch).
+3.  The stream should start.
+
+### Troubleshooting
+
+*   **Black Screen / No Display**:
+    *   Ensure the HDMI dummy plug is connected if the system is headless.
+    *   Check if the X server is running: `systemctl status display-manager`.
+*   **Input Lag**:
+    *   Ensure Game Mode on your TV/Monitor is ON if connected (though less relevant for iPad).
+    *   Use 5GHz Wi-Fi or a wired Ethernet adapter for the iPad for best results.
+*   **Resolution Mismatch**:
+    *   If the desktop looks stretched or has black bars, ensure the Linux desktop resolution matches the Moonlight stream resolution. You can change the Linux resolution via the Display Settings in the desktop environment (GNOME/KDE/XFCE) once you are connected.
+*   **Permission Errors / No Encoder Found**:
+    *   If you see errors like `Permission denied` for `/dev/dri/card*` or `Unable to create virtual mouse`, ensure your user is in the `video` and `input` groups.
+    *   Run: `sudo usermod -aG video,input $USER` and **restart your computer**.

--- a/templates/sunshine-override.conf
+++ b/templates/sunshine-override.conf
@@ -1,3 +1,11 @@
+[Unit]
+# Ensure graphical session is available before starting
+Wants=graphical-session.target
+After=graphical-session.target
+
 [Service]
 Environment="DISPLAY=:0"
-Environment="XAUTHORITY=/run/user/1000/gdm/Xauthority"
+Environment="XAUTHORITY=/run/user/%U/gdm/Xauthority"
+# Auto-restart on failure for reliability
+Restart=on-failure
+RestartSec=5

--- a/templates/sunshine.conf.template
+++ b/templates/sunshine.conf.template
@@ -23,3 +23,13 @@ nvenc_rc = cbr
 
 # Performance
 channels = 2
+
+# Custom Resolutions
+# iPad Pro 12.9 M2 (2732x2048) and Dell AW3420DW (3440x1440)
+resolutions = [
+    3840x2160,
+    3440x1440,
+    2732x2048,
+    2560x1440,
+    1920x1080
+]

--- a/templates/sunshine.service
+++ b/templates/sunshine.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Sunshine Game Streaming Host
+Documentation=https://docs.lizardbyte.dev/projects/sunshine/
+After=graphical-session.target
+Wants=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/sunshine
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/templates/xorg.conf.template
+++ b/templates/xorg.conf.template
@@ -13,7 +13,7 @@ Section "Screen"
     DefaultDepth    24
     SubSection "Display"
         Depth       24
-        Modes      "3840x2160" "2560x1440" "1920x1080"
+        Modes      "3840x2160" "3440x1440" "2732x2048" "2560x1440" "1920x1080"
     EndSubSection
 EndSection
 
@@ -23,8 +23,8 @@ Section "Device"
     VendorName     "NVIDIA Corporation"
     BoardName      "GB10"
     BusID          "{{BUS_ID}}"
-    Option         "ConnectedMonitor" "DFP-0"
-    Option         "CustomEDID" "DFP-0:{{EDID_PATH}}"
+    Option         "ConnectedMonitor" "TV-0"
+    Option         "CustomEDID" "TV-0:{{EDID_PATH}}"
     Option         "IgnoreEDID" "false"
     Option         "UseEdidDpi" "false"
     Option         "AllowEmptyInitialConfiguration" "true"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,291 @@
+#!/bin/bash
+# ============================================================================
+# NVIDIA DGX Spark Sunshine Streaming Setup Uninstaller
+# ============================================================================
+# Completely removes Sunshine and all related configurations
+# ============================================================================
+
+set -e  # Exit on error
+
+# ============================================================================
+# Colors and Formatting (NVIDIA Green Theme)
+# ============================================================================
+readonly NVIDIA_GREEN='\033[38;5;112m'
+readonly BRIGHT_GREEN='\033[1;32m'
+readonly WHITE='\033[1;37m'
+readonly GRAY='\033[0;37m'
+readonly RED='\033[1;31m'
+readonly YELLOW='\033[1;33m'
+readonly BLUE='\033[1;34m'
+readonly RESET='\033[0m'
+readonly BOLD='\033[1m'
+readonly DIM='\033[2m'
+
+# ============================================================================
+# Configuration
+# ============================================================================
+readonly SUNSHINE_CONFIG_DIR="${HOME}/.config/sunshine"
+readonly SYSTEMD_USER_DIR="${HOME}/.config/systemd/user"
+
+# ============================================================================
+# Utility Functions
+# ============================================================================
+log_info() {
+    echo -e "${NVIDIA_GREEN}▶${RESET} $1"
+}
+
+log_success() {
+    echo -e "${BRIGHT_GREEN}✓${RESET} $1"
+}
+
+log_error() {
+    echo -e "${RED}✗${RESET} $1" >&2
+}
+
+log_warning() {
+    echo -e "${YELLOW}⚠${RESET} $1"
+}
+
+log_step() {
+    echo ""
+    echo -e "${BLUE}${BOLD}┌─ $1${RESET}"
+}
+
+log_substep() {
+    echo -e "${GRAY}│${RESET}  $1"
+}
+
+log_complete() {
+    echo -e "${BLUE}${BOLD}└─${RESET} ${BRIGHT_GREEN}Complete${RESET}"
+}
+
+confirm() {
+    local prompt="$1"
+    local response
+    echo -ne "${YELLOW}?${RESET} ${prompt} ${DIM}[y/N]${RESET}: "
+    read -r response
+    [[ "${response}" =~ ^[Yy]$ ]]
+}
+
+# ============================================================================
+# Print Header
+# ============================================================================
+print_header() {
+    echo ""
+    echo -e "${RED}${BOLD}"
+    echo "  ╔═══════════════════════════════════════════════════════════════╗"
+    echo "  ║                 SUNSHINE UNINSTALLER                          ║"
+    echo "  ║           DGX Spark Streaming Setup Removal                   ║"
+    echo "  ╚═══════════════════════════════════════════════════════════════╝"
+    echo -e "${RESET}"
+    echo -e "${YELLOW}This will completely remove Sunshine and all related configurations.${RESET}"
+    echo ""
+}
+
+# ============================================================================
+# Stop Sunshine Service
+# ============================================================================
+stop_sunshine_service() {
+    log_step "Stopping Sunshine Service"
+
+    if systemctl --user is-active sunshine &>/dev/null; then
+        log_substep "Stopping sunshine service..."
+        systemctl --user stop sunshine
+        log_success "Sunshine service stopped"
+    else
+        log_substep "Sunshine service is not running"
+    fi
+
+    if systemctl --user is-enabled sunshine &>/dev/null; then
+        log_substep "Disabling sunshine service..."
+        systemctl --user disable sunshine
+        log_success "Sunshine service disabled"
+    else
+        log_substep "Sunshine service is not enabled"
+    fi
+
+    log_complete
+}
+
+# ============================================================================
+# Remove Sunshine Package
+# ============================================================================
+remove_sunshine_package() {
+    log_step "Removing Sunshine Package"
+
+    if dpkg -l | grep -q "^ii  sunshine"; then
+        log_substep "Removing sunshine package..."
+        sudo apt-get remove --purge -y sunshine
+        log_success "Sunshine package removed"
+    else
+        log_warning "Sunshine package not found"
+    fi
+
+    # Clean up any leftover dependencies
+    log_substep "Cleaning up unused dependencies..."
+    sudo apt-get autoremove -y
+    log_success "Dependencies cleaned"
+
+    log_complete
+}
+
+# ============================================================================
+# Remove Configuration Files
+# ============================================================================
+remove_configurations() {
+    log_step "Removing Configuration Files"
+
+    # Remove Sunshine config directory
+    if [[ -d "${SUNSHINE_CONFIG_DIR}" ]]; then
+        log_substep "Removing ${SUNSHINE_CONFIG_DIR}..."
+        rm -rf "${SUNSHINE_CONFIG_DIR}"
+        log_success "Sunshine config directory removed"
+    else
+        log_substep "Sunshine config directory not found"
+    fi
+
+    # Remove systemd service files
+    if [[ -f "${SYSTEMD_USER_DIR}/sunshine.service" ]]; then
+        log_substep "Removing sunshine.service..."
+        rm -f "${SYSTEMD_USER_DIR}/sunshine.service"
+        log_success "User sunshine.service removed"
+    fi
+
+    if [[ -d "${SYSTEMD_USER_DIR}/sunshine.service.d" ]]; then
+        log_substep "Removing sunshine.service.d override directory..."
+        rm -rf "${SYSTEMD_USER_DIR}/sunshine.service.d"
+        log_success "Systemd override directory removed"
+    fi
+
+    # Reload systemd
+    log_substep "Reloading systemd daemon..."
+    systemctl --user daemon-reload
+    log_success "Systemd reloaded"
+
+    log_complete
+}
+
+# ============================================================================
+# Remove X11 Configuration
+# ============================================================================
+remove_x11_config() {
+    log_step "Removing X11 Configuration"
+
+    # Remove xorg.conf
+    if [[ -f "/etc/X11/xorg.conf" ]]; then
+        log_substep "Removing /etc/X11/xorg.conf..."
+        sudo rm -f /etc/X11/xorg.conf
+        log_success "xorg.conf removed"
+        log_warning "X11 will use default auto-configuration after restart"
+    else
+        log_substep "xorg.conf not found"
+    fi
+
+    # Remove EDID file
+    if [[ -f "/etc/X11/4k120.edid" ]]; then
+        log_substep "Removing /etc/X11/4k120.edid..."
+        sudo rm -f /etc/X11/4k120.edid
+        log_success "EDID file removed"
+    else
+        log_substep "EDID file not found"
+    fi
+
+    log_complete
+}
+
+# ============================================================================
+# Remove udev Rules
+# ============================================================================
+remove_udev_rules() {
+    log_step "Removing udev Rules"
+
+    if [[ -f "/etc/udev/rules.d/85-sunshine.rules" ]]; then
+        log_substep "Removing /etc/udev/rules.d/85-sunshine.rules..."
+        sudo rm -f /etc/udev/rules.d/85-sunshine.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger
+        log_success "Sunshine udev rules removed"
+    else
+        log_substep "Sunshine udev rules not found"
+    fi
+
+    log_complete
+}
+
+# ============================================================================
+# Optional: Remove User from Groups
+# ============================================================================
+remove_user_groups() {
+    log_step "User Group Cleanup"
+
+    echo ""
+    echo -e "${YELLOW}The installer added your user to 'video' and 'input' groups.${RESET}"
+    echo -e "${GRAY}These groups are commonly used by other applications too.${RESET}"
+    echo ""
+
+    if confirm "Remove user from 'video' and 'input' groups?"; then
+        log_substep "Removing user from groups..."
+        sudo deluser "${USER}" video 2>/dev/null || true
+        sudo deluser "${USER}" input 2>/dev/null || true
+        log_success "User removed from groups"
+        log_warning "Changes will take effect after logout/reboot"
+    else
+        log_info "Keeping user in video and input groups"
+    fi
+
+    log_complete
+}
+
+# ============================================================================
+# Print Final Message
+# ============================================================================
+print_final_message() {
+    echo ""
+    echo -e "${NVIDIA_GREEN}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
+    echo -e "${WHITE}${BOLD}Uninstallation Complete!${RESET}"
+    echo -e "${NVIDIA_GREEN}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
+    echo ""
+    echo -e "${WHITE}${BOLD}What was removed:${RESET}"
+    echo -e "${GRAY}  ✓${RESET} Sunshine package"
+    echo -e "${GRAY}  ✓${RESET} Sunshine configuration (~/.config/sunshine)"
+    echo -e "${GRAY}  ✓${RESET} Systemd user service files"
+    echo -e "${GRAY}  ✓${RESET} X11 xorg.conf (virtual display config)"
+    echo -e "${GRAY}  ✓${RESET} Custom EDID file"
+    echo -e "${GRAY}  ✓${RESET} Sunshine udev rules"
+    echo ""
+    echo -e "${YELLOW}${BOLD}Recommended:${RESET}"
+    echo -e "${GRAY}  •${RESET} Restart your system: ${DIM}sudo reboot${RESET}"
+    echo ""
+    echo -e "${NVIDIA_GREEN}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
+    echo ""
+}
+
+# ============================================================================
+# Main Uninstall Flow
+# ============================================================================
+main() {
+    print_header
+
+    if ! confirm "Are you sure you want to completely uninstall Sunshine?"; then
+        log_warning "Uninstallation cancelled"
+        exit 0
+    fi
+
+    echo ""
+
+    stop_sunshine_service
+    remove_sunshine_package
+    remove_configurations
+    remove_x11_config
+    remove_udev_rules
+    remove_user_groups
+
+    print_final_message
+}
+
+# ============================================================================
+# Entry Point
+# ============================================================================
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi


### PR DESCRIPTION
@devkwang fixed and enhanced the following

Update dgx-spark-sunshine-setup to use the latest version of sunshine and fix the issue of sunshine not starting automatically.

1. Add ipad 12.9 pro M2 resolution to the sunshine config.
2. Update all DGX spark to the latest version, Ubuntu 24.04.3 LTS and DGX OS 7.3.1.
3. Install sunshine using the latest version from the official website.
4. Fix the issue of sunshine not starting automatically.
5. Add the support for Dell AW3420DW to the sunshine config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ultrawide (3440x1440) and iPad Pro (2732x2048) display resolutions
  * New iPad Moonlight streaming setup guide with pairing and configuration steps
  * Added uninstaller tool for complete system removal
  * Improved auto-start functionality with session persistence verification

* **Documentation**
  * Updated OS requirements to Ubuntu 24.04.3 LTS (DGX OS 7.3.1 or newer)
  * Added troubleshooting section for auto-start recovery after reboot

<!-- end of auto-generated comment: release notes by coderabbit.ai -->