### PR TITLE
Tailscale uninstall

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -739,21 +739,58 @@ configure_tailscale() {
         log_success "Tailscale already installed"
     else
         log_substep "Installing Tailscale..."
-        if sudo apt-get update; then
-            if sudo apt-get install -y tailscale; then
-                log_success "Tailscale installed"
+
+        # Detect Ubuntu codename for the Tailscale apt repo
+        local codename=""
+        if [[ -f /etc/os-release ]]; then
+            codename=$(. /etc/os-release && echo "${VERSION_CODENAME}")
+        fi
+        if [[ -z "${codename}" ]]; then
+            codename=$(lsb_release -cs 2>/dev/null || true)
+        fi
+
+        if [[ -n "${codename}" ]]; then
+            log_substep "Detected Ubuntu codename: ${DIM}${codename}${RESET}"
+            log_substep "Adding Tailscale package repository..."
+
+            local ts_base="https://pkgs.tailscale.com/stable/ubuntu"
+            if curl -fsSL "${ts_base}/${codename}.noarmor.gpg" | sudo tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null \
+                && curl -fsSL "${ts_base}/${codename}.tailscale-keyring.list" | sudo tee /etc/apt/sources.list.d/tailscale.list >/dev/null; then
+                log_success "Tailscale repository added"
             else
-                log_warning "Failed to install Tailscale via apt"
-                log_substep "To install manually: ${DIM}sudo apt-get update && sudo apt-get install -y tailscale${RESET}"
-                log_substep "Or see: ${DIM}https://tailscale.com/download/linux${RESET}"
+                log_warning "Failed to add Tailscale repository for codename '${codename}'"
+                log_substep "Falling back to Tailscale install script..."
+                if curl -fsSL https://tailscale.com/install.sh | sh; then
+                    log_success "Tailscale installed via install script"
+                else
+                    log_warning "Failed to install Tailscale"
+                    log_substep "To install manually, see: ${DIM}https://tailscale.com/download/linux${RESET}"
+                    log_complete
+                    return
+                fi
+            fi
+        else
+            log_warning "Could not detect Ubuntu codename — using Tailscale install script"
+            if curl -fsSL https://tailscale.com/install.sh | sh; then
+                log_success "Tailscale installed via install script"
+            else
+                log_warning "Failed to install Tailscale"
+                log_substep "To install manually, see: ${DIM}https://tailscale.com/download/linux${RESET}"
                 log_complete
                 return
             fi
-        else
-            log_warning "Failed to update package lists - skipping Tailscale installation"
-            log_substep "Try later: ${DIM}sudo apt-get update && sudo apt-get install -y tailscale${RESET}"
-            log_complete
-            return
+        fi
+
+        # Install the package if the repo was added (skip if install script already handled it)
+        if ! command -v tailscale &> /dev/null; then
+            if sudo apt-get update && sudo apt-get install -y tailscale; then
+                log_success "Tailscale installed"
+            else
+                log_warning "Failed to install Tailscale via apt"
+                log_substep "To install manually, see: ${DIM}https://tailscale.com/download/linux${RESET}"
+                log_complete
+                return
+            fi
         fi
     fi
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -2,7 +2,7 @@
 # ============================================================================
 # NVIDIA DGX Spark Sunshine Streaming Setup Uninstaller
 # ============================================================================
-# Completely removes Sunshine and all related configurations
+# Completely removes Sunshine, Tailscale, and all related configurations
 # ============================================================================
 
 set -eo pipefail  # Exit on error, catch pipeline failures
@@ -275,10 +275,10 @@ restore_backups() {
 
     # Find the latest backup
     local latest_backup
-    latest_backup=$(ls -dt "${backup_base}"/backup-* 2>/dev/null | head -1)
+    latest_backup=$(ls -dt "${backup_base}"/backup-* 2>/dev/null | head -1 || true)
     # Handle old format without backup- prefix
     if [[ -z "${latest_backup}" ]]; then
-        latest_backup=$(ls -dt "${backup_base}"/*/ 2>/dev/null | head -1)
+        latest_backup=$(ls -dt "${backup_base}"/*/ 2>/dev/null | head -1 || true)
     fi
 
     if [[ -z "${latest_backup}" || ! -d "${latest_backup}" ]]; then
@@ -317,6 +317,86 @@ restore_backups() {
 }
 
 # ============================================================================
+# Optional: Remove Tailscale
+# ============================================================================
+remove_tailscale() {
+    log_step "Optional: Tailscale Removal"
+
+    if ! command -v tailscale &> /dev/null && ! dpkg -l tailscale 2>/dev/null | grep -q "^[ih]i"; then
+        log_substep "Tailscale is not installed — skipping"
+        log_complete
+        return
+    fi
+
+    echo ""
+    echo -e "${YELLOW}Tailscale was optionally installed for remote access.${RESET}"
+    echo -e "${GRAY}You may want to keep it if you use it for other purposes.${RESET}"
+    echo ""
+
+    if ! confirm "Remove Tailscale?"; then
+        log_info "Keeping Tailscale"
+        log_complete
+        return
+    fi
+
+    # Stop and disable the autoconnect service if present
+    if systemctl is-active tailscale-autoconnect &>/dev/null || systemctl is-enabled tailscale-autoconnect &>/dev/null; then
+        log_substep "Stopping tailscale-autoconnect service..."
+        sudo systemctl disable --now tailscale-autoconnect 2>/dev/null || true
+        log_success "tailscale-autoconnect service stopped and disabled"
+    fi
+
+    # Remove the autoconnect service and env files
+    if [[ -f "/etc/systemd/system/tailscale-autoconnect.service" ]]; then
+        log_substep "Removing tailscale-autoconnect service file..."
+        sudo rm -f /etc/systemd/system/tailscale-autoconnect.service
+        log_success "tailscale-autoconnect service file removed"
+    fi
+    if [[ -f "/etc/default/tailscale-autoconnect" ]]; then
+        log_substep "Removing tailscale-autoconnect config..."
+        sudo rm -f /etc/default/tailscale-autoconnect
+        log_success "tailscale-autoconnect config removed"
+    fi
+
+    # Disconnect from tailnet before removing
+    if command -v tailscale &> /dev/null; then
+        log_substep "Disconnecting from Tailscale network..."
+        sudo tailscale down 2>/dev/null || true
+    fi
+
+    # Stop tailscaled
+    if systemctl is-active tailscaled &>/dev/null; then
+        log_substep "Stopping tailscaled service..."
+        sudo systemctl disable --now tailscaled 2>/dev/null || true
+        log_success "tailscaled stopped and disabled"
+    fi
+
+    # Remove the package
+    log_substep "Removing tailscale package..."
+    if sudo apt-get remove --purge -y tailscale 2>/dev/null; then
+        log_success "Tailscale package removed"
+    else
+        log_warning "Could not remove tailscale package via apt"
+    fi
+
+    # Remove the apt repository and signing key added by the installer
+    if [[ -f "/etc/apt/sources.list.d/tailscale.list" ]]; then
+        log_substep "Removing Tailscale apt repository..."
+        sudo rm -f /etc/apt/sources.list.d/tailscale.list
+        log_success "Tailscale apt source removed"
+    fi
+    if [[ -f "/usr/share/keyrings/tailscale-archive-keyring.gpg" ]]; then
+        log_substep "Removing Tailscale signing key..."
+        sudo rm -f /usr/share/keyrings/tailscale-archive-keyring.gpg
+        log_success "Tailscale signing key removed"
+    fi
+
+    sudo systemctl daemon-reload 2>/dev/null || true
+
+    log_complete
+}
+
+# ============================================================================
 # Print Final Message
 # ============================================================================
 print_final_message() {
@@ -332,6 +412,7 @@ print_final_message() {
     echo -e "${GRAY}  ✓${RESET} X11 xorg.conf (virtual display config)"
     echo -e "${GRAY}  ✓${RESET} Custom EDID file"
     echo -e "${GRAY}  ✓${RESET} Sunshine udev rules"
+    echo -e "${GRAY}  ✓${RESET} Tailscale (if selected)"
     echo ""
     echo -e "${YELLOW}${BOLD}Recommended:${RESET}"
     echo -e "${GRAY}  •${RESET} Restart your system: ${DIM}sudo reboot${RESET}"
@@ -360,6 +441,7 @@ main() {
     restore_backups
     remove_udev_rules
     remove_user_groups
+    remove_tailscale
 
     print_final_message
 }


### PR DESCRIPTION
https://github.com/seanGSISG/dgx-spark-sunshine-setup/pull/5 should be merged first.

This just adds tailscale removal to the uninstall script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Tailscale removal option during uninstallation, including service cleanup and configuration removal.

* **Improvements**
  * Enhanced Tailscale installation with automatic OS detection and fallback mechanisms for improved reliability.
  * Improved backup restoration with enhanced fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->