### PR TITLE
Fix sunshine.conf defaults for Ubuntu 24.04 + NVIDIA GB10

### DIFF
--- a/templates/sunshine.conf.template
+++ b/templates/sunshine.conf.template
@@ -8,7 +8,21 @@
 # origin_web_ui_allowed = wan
 
 # Display Output
-output_name = HDMI-0
+# Use X11 capture rather than the default KMS path. On Ubuntu 24.04 the
+# unprivileged_userns AppArmor profile strips CAP_SYS_ADMIN from sunshine
+# and KMS capture fails. Upstream Sunshine recommends moving away from
+# KMS regardless. See:
+# https://docs.lizardbyte.dev/projects/sunshine/latest/md_docs_2troubleshooting.html#kms-streaming-fails
+capture = x11
+
+# output_name must be the numeric Sunshine display index, not the X
+# connector name. On the DGX Spark, the NVIDIA driver can misresolve the
+# string form to a RandR XID which Sunshine then uses as a list index,
+# producing "Could not stream display number [N], there are only [M]
+# displays". On the GB10, index 0 is HDMI-0 and indices 1-4 are the
+# USB-C ports. If capture fails, check Sunshine startup logs for the
+# listed display ids.
+output_name = 0
 
 # Video Encoding Settings
 encoder = nvenc


### PR DESCRIPTION
After installing on two clean DGX Spark units, Sunshine starts cleanly but every encoder probe fails with:

```
Fatal: Unable to find display or encoder during startup.
Fatal: Please ensure your manually chosen GPU and monitor are connected and powered on.
Error: Video failed to find working encoder
```

Two defaults in `templates/sunshine.conf.template` are responsible. This PR fixes both.

### 1. `capture` defaults to KMS, which fails on Ubuntu 24.04

Without an explicit `capture` setting, Sunshine tries KMS first. Ubuntu 24.04's `unprivileged_userns` AppArmor profile auto-attaches to processes that create user namespaces and strips CAP_SYS_ADMIN, which makes KMS capture fail (`Failed to gain CAP_SYS_ADMIN` / `/dev/dri/card1: Permission denied`).

Setting `capture = x11` skips KMS entirely. Per [LizardByte's KMS troubleshooting doc](https://docs.lizardbyte.dev/projects/sunshine/latest/md_docs_2troubleshooting.html#kms-streaming-fails), upstream recommends moving away from KMS anyway (it's being phased out in favor of XDG Portal Capture).

### 2. `output_name = HDMI-0` triggers an NVIDIA driver misresolution

The NVIDIA driver resolves the string `HDMI-0` to its internal RandR output XID, which Sunshine then uses as a list index:

```
Could not stream display number [2631470], there are only [5] displays.
```

Using the numeric Sunshine display index (`output_name = 0`) bypasses the lookup. On the GB10, index 0 is HDMI-0 and indices 1-4 are the USB-C ports.

### Reproduction

- DGX OS: 7.5.0 (build 7.2.3, commit \`833b4a7\`)
- Kernel: \`6.17.0-1014-nvidia\` aarch64
- Driver: NVIDIA 580.142, CUDA 13.0
- Sunshine: 2025.924.154138
- Configuration: 1440p HEVC 100 Mbps
- Reproduced on two Sparks. Fix verified on both: encoder probe completes, all three NVENC encoders found (\`h264_nvenc\`, \`hevc_nvenc\`, \`av1_nvenc\`), Moonlight pairs and streams cleanly.

### Notes

A few other rough edges in the post-install state are worth addressing (auto-login population, XAUTHORITY plumbing in the override, the \`.xprofile\` dbus line, monitor-vs-headless install prompt). Those are larger / more opinionated changes; happy to open them as a separate issue for discussion before any further PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Sunshine configuration template with improved display capture settings, now using X11 capture method and numeric display indexing for enhanced compatibility and clarity on target hardware platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seanGSISG/dgx-spark-sunshine-setup/pull/8)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->