### PR TITLE
Add install-mode prompt: monitor or headless

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -35,6 +35,7 @@ readonly SUNSHINE_CONFIG_DIR="${HOME}/.config/sunshine"
 readonly SYSTEMD_USER_DIR="${HOME}/.config/systemd/user"
 
 # User selections (set via prompts)
+INSTALL_MODE=""
 RESOLUTION=""
 REFRESH_RATE=""
 CODEC=""
@@ -611,7 +612,18 @@ configure_x11() {
     log_step "Configuring X11"
 
     if [[ "${INSTALL_MODE}" == "monitor" ]]; then
-        log_substep "Monitor mode: not installing /etc/X11/xorg.conf"
+        if [[ -f "/etc/X11/xorg.conf" ]]; then
+            if sudo grep -q "DGX Spark Sunshine Setup Installer" /etc/X11/xorg.conf 2>/dev/null; then
+                log_substep "Monitor mode: removing previous installer-managed /etc/X11/xorg.conf"
+                sudo rm -f /etc/X11/xorg.conf
+                log_success "Removed installer-managed xorg.conf"
+            else
+                log_warning "Existing /etc/X11/xorg.conf was not created by this installer; leaving it in place"
+                log_substep "If display issues persist, inspect or remove it manually"
+            fi
+        else
+            log_substep "Monitor mode: no xorg.conf installed"
+        fi
         log_substep "The NVIDIA driver will auto-detect connected displays"
         log_complete
         return 0
@@ -1005,7 +1017,17 @@ validate_installation() {
             ((errors++))
         fi
     else
-        log_substep "Monitor mode: skipping xorg.conf and EDID checks"
+        log_substep "Checking monitor-mode X11 configuration..."
+        if [[ -f "/etc/X11/xorg.conf" ]]; then
+            if sudo grep -q "DGX Spark Sunshine Setup Installer" /etc/X11/xorg.conf 2>/dev/null; then
+                log_error "Installer-managed xorg.conf still exists in monitor mode"
+                ((errors++))
+            else
+                log_warning "Custom /etc/X11/xorg.conf exists; monitor mode will not fully rely on auto-detection"
+            fi
+        else
+            log_success "No installer-managed xorg.conf active"
+        fi
     fi
 
     # Check Sunshine config

--- a/install.sh
+++ b/install.sh
@@ -224,6 +224,15 @@ check_prerequisites() {
 configure_install_mode() {
     log_step "Installation Mode"
 
+    # Honor a pre-exported INSTALL_MODE so the installer works under CI,
+    # Ansible, or any other non-interactive re-run path without blocking
+    # on a prompt. Accepts exactly the two values the interactive path can set.
+    if [[ "${INSTALL_MODE:-}" =~ ^(monitor|headless)$ ]]; then
+        log_substep "Mode: ${INSTALL_MODE} (from environment)"
+        log_complete
+        return 0
+    fi
+
     echo ""
     echo -e "${WHITE}${BOLD}How will this Spark be used?${RESET}"
     echo ""
@@ -239,8 +248,9 @@ configure_install_mode() {
 
     local choice
     while true; do
-        prompt_user "Select installation mode (1-2)" choice
-        case "${choice}" in
+        prompt_user "Select installation mode (1-2) [1]" choice
+        # Bare Enter selects 1 (Recommended), matching the [1] hint in the prompt.
+        case "${choice:-1}" in
             1)
                 INSTALL_MODE="monitor"
                 log_substep "Mode: monitor or dummy plug"

--- a/install.sh
+++ b/install.sh
@@ -207,6 +207,58 @@ check_prerequisites() {
 # ============================================================================
 # Interactive Configuration
 # ============================================================================
+# Two ways to set up a Spark for sunshine:
+#
+#   monitor  - A real monitor or an HDMI dummy plug is always connected.
+#              The NVIDIA driver auto-detects whatever is plugged in, and
+#              no synthetic xorg.conf is installed. Recommended for most.
+#
+#   headless - Truly headless, with nothing plugged into the GPU. Installs
+#              an xorg.conf that drives a virtual TV-0 connector with a
+#              custom EDID so sunshine can still capture a display.
+#              Will break if a real monitor is later connected.
+#
+# Sets the INSTALL_MODE global. install_edid, configure_x11, and the
+# validation step honor it.
+configure_install_mode() {
+    log_step "Installation Mode"
+
+    echo ""
+    echo -e "${WHITE}${BOLD}How will this Spark be used?${RESET}"
+    echo ""
+    echo -e "${GRAY}  1)${RESET} ${BOLD}Monitor or HDMI dummy plug attached${RESET} ${NVIDIA_GREEN}[Recommended]${RESET}"
+    echo -e "${GRAY}     Streams whatever the GPU sees. Suitable for desktop use and"
+    echo -e "${GRAY}     for streaming with a real monitor or a passive HDMI dummy plug.${RESET}"
+    echo ""
+    echo -e "${GRAY}  2)${RESET} ${BOLD}Truly headless${RESET} ${DIM}(no monitor, no dummy plug, ever)${RESET}"
+    echo -e "${GRAY}     Installs a virtual-display xorg.conf with a custom EDID so"
+    echo -e "${GRAY}     sunshine can capture with nothing physically connected.${RESET}"
+    echo -e "${GRAY}     Streaming will break if you later plug a monitor in.${RESET}"
+    echo ""
+
+    local choice
+    while true; do
+        prompt_user "Select installation mode (1-2)" choice
+        case "${choice}" in
+            1)
+                INSTALL_MODE="monitor"
+                log_substep "Mode: monitor or dummy plug"
+                break
+                ;;
+            2)
+                INSTALL_MODE="headless"
+                log_substep "Mode: truly headless"
+                break
+                ;;
+            *)
+                log_error "Invalid selection. Please choose 1-2."
+                ;;
+        esac
+    done
+
+    log_complete
+}
+
 configure_resolution() {
     log_step "Display Configuration"
 
@@ -322,6 +374,13 @@ configure_bitrate() {
 configure_edid() {
     log_step "EDID Configuration"
 
+    if [[ "${INSTALL_MODE}" == "monitor" ]]; then
+        log_substep "Monitor mode: using whatever EDID the connected display provides"
+        EDID_SOURCE="none"
+        log_complete
+        return 0
+    fi
+
     echo ""
     echo -e "${WHITE}${BOLD}EDID Options:${RESET}"
     echo -e "${GRAY}  1)${RESET} Use bundled Samsung Q800T EDID ${DIM}(4K@60Hz, 1440p@120Hz)${RESET} ${NVIDIA_GREEN}[Recommended]${RESET}"
@@ -363,12 +422,15 @@ print_configuration_summary() {
     echo -e "${NVIDIA_GREEN}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
     echo -e "${WHITE}${BOLD}Configuration Summary${RESET}"
     echo -e "${NVIDIA_GREEN}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
+    echo -e "${GRAY}  Mode:${RESET}        ${INSTALL_MODE}"
     echo -e "${GRAY}  Resolution:${RESET}  ${RESOLUTION} @ ${REFRESH_RATE}Hz"
     echo -e "${GRAY}  Codec:${RESET}       ${CODEC}"
     echo -e "${GRAY}  Bitrate:${RESET}     $((BITRATE / 1000)) Mbps"
-    echo -e "${GRAY}  EDID Source:${RESET} ${EDID_SOURCE}"
-    if [[ "${EDID_SOURCE}" == "custom" ]]; then
-        echo -e "${GRAY}  EDID Path:${RESET}   ${CUSTOM_EDID_PATH}"
+    if [[ "${INSTALL_MODE}" == "headless" ]]; then
+        echo -e "${GRAY}  EDID Source:${RESET} ${EDID_SOURCE}"
+        if [[ "${EDID_SOURCE}" == "custom" ]]; then
+            echo -e "${GRAY}  EDID Path:${RESET}   ${CUSTOM_EDID_PATH}"
+        fi
     fi
     echo -e "${NVIDIA_GREEN}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
     echo ""
@@ -507,6 +569,12 @@ install_sunshine() {
 install_edid() {
     log_step "Installing EDID File"
 
+    if [[ "${INSTALL_MODE}" == "monitor" ]]; then
+        log_substep "Monitor mode: skipping EDID file install"
+        log_complete
+        return 0
+    fi
+
     local source_edid
     if [[ "${EDID_SOURCE}" == "bundled" ]]; then
         source_edid="${EDID_DIR}/samsung-q800t.bin"
@@ -541,6 +609,13 @@ install_edid() {
 # ============================================================================
 configure_x11() {
     log_step "Configuring X11"
+
+    if [[ "${INSTALL_MODE}" == "monitor" ]]; then
+        log_substep "Monitor mode: not installing /etc/X11/xorg.conf"
+        log_substep "The NVIDIA driver will auto-detect connected displays"
+        log_complete
+        return 0
+    fi
 
     # Detect GPU BusID
     log_substep "Detecting NVIDIA GPU BusID..."
@@ -905,28 +980,32 @@ validate_installation() {
         ((errors++))
     fi
 
-    # Check xorg.conf
-    log_substep "Checking xorg.conf..."
-    if [[ -f "/etc/X11/xorg.conf" ]]; then
-        log_success "xorg.conf exists"
-        if grep -q "CustomEDID" /etc/X11/xorg.conf; then
-            log_success "CustomEDID option found"
+    # Check xorg.conf (only in headless mode)
+    if [[ "${INSTALL_MODE}" == "headless" ]]; then
+        log_substep "Checking xorg.conf..."
+        if [[ -f "/etc/X11/xorg.conf" ]]; then
+            log_success "xorg.conf exists"
+            if grep -q "CustomEDID" /etc/X11/xorg.conf; then
+                log_success "CustomEDID option found"
+            else
+                log_error "CustomEDID option not found in xorg.conf"
+                ((errors++))
+            fi
         else
-            log_error "CustomEDID option not found in xorg.conf"
+            log_error "xorg.conf not found"
+            ((errors++))
+        fi
+
+        # Check EDID file
+        log_substep "Checking EDID file..."
+        if [[ -f "/etc/X11/4k120.edid" ]]; then
+            log_success "EDID file exists"
+        else
+            log_error "EDID file not found"
             ((errors++))
         fi
     else
-        log_error "xorg.conf not found"
-        ((errors++))
-    fi
-
-    # Check EDID file
-    log_substep "Checking EDID file..."
-    if [[ -f "/etc/X11/4k120.edid" ]]; then
-        log_success "EDID file exists"
-    else
-        log_error "EDID file not found"
-        ((errors++))
+        log_substep "Monitor mode: skipping xorg.conf and EDID checks"
     fi
 
     # Check Sunshine config
@@ -968,7 +1047,12 @@ print_final_instructions() {
     echo -e "${WHITE}${BOLD}Next Steps:${RESET}"
     echo ""
     echo -e "${NVIDIA_GREEN}1.${RESET} ${BOLD}Restart your system${RESET}"
-    echo -e "${GRAY}   └─${RESET} Required for X11 to load new virtual display configuration"
+    if [[ "${INSTALL_MODE}" == "headless" ]]; then
+        echo -e "${GRAY}   └─${RESET} Required for X11 to load the new virtual display configuration"
+    else
+        echo -e "${GRAY}   └─${RESET} Recommended so group changes and session updates take effect"
+        echo -e "${GRAY}   └─${RESET} Keep a monitor or HDMI dummy plug connected for sunshine to capture"
+    fi
     echo -e "${GRAY}   └─${RESET} Run: ${DIM}sudo reboot${RESET}"
     echo ""
     echo -e "${NVIDIA_GREEN}2.${RESET} ${BOLD}Run the post-installation helper${RESET} ${DIM}(Recommended)${RESET}"
@@ -1011,6 +1095,7 @@ main() {
     check_prerequisites
 
     # Interactive configuration
+    configure_install_mode
     configure_resolution
     configure_codec
     configure_bitrate


### PR DESCRIPTION
## Problem

The installer always writes `/etc/X11/xorg.conf` with a virtual TV-0 connector and a custom EDID. This is correct for a truly headless Spark with nothing plugged into the GPU, but it breaks setups where a real monitor or HDMI dummy plug is attached.

Observed failure modes when the installer-managed `xorg.conf` is present with a display attached:
- On one Spark, X started using the virtual EDID and disabled physical HDMI output, leaving the screen black.
- On another, X failed to start at all (`No devices detected`), and GDM gave up after several retries.

Both are silent failures from the user's perspective: the installer reports success.

## Changes

Add an interactive prompt at the start of installation:

```
┌─ Installation Mode
│
│  How will this Spark be used?
│
│    1) Monitor or HDMI dummy plug attached  [Recommended]
│       Streams whatever the GPU sees. Suitable for desktop use and
│       for streaming with a real monitor or a passive HDMI dummy plug.
│
│    2) Truly headless  (no monitor, no dummy plug, ever)
│       Installs a virtual-display xorg.conf with a custom EDID so
│       sunshine can capture with nothing physically connected.
│       Streaming will break if you later plug a monitor in.
```

The selection sets `INSTALL_MODE` (`monitor` or `headless`) which gates:

- `configure_edid` — skipped in monitor mode
- `install_edid` — skipped in monitor mode
- `configure_x11` — skipped in monitor mode (no synthetic `xorg.conf` written)
- `validate_installation` — checks the right things for each mode
- Configuration summary and final instructions — reflect the choice

In headless mode, behavior is unchanged.

## Stale xorg.conf handling

A second commit handles the case where someone first ran the installer in headless mode, then re-runs it in monitor mode. The previously installed `xorg.conf` would still be active and would break monitor mode the same way it does on a fresh install.

`configure_x11` and `validate_installation` now detect an installer-managed `xorg.conf` (matched by the header comment string) and remove it in monitor mode. A non-installer-managed `xorg.conf` is left in place with a warning, so user-authored config is never touched.

## Test plan

- [x] Fresh install with mode 1 on a Spark with a real monitor: no `xorg.conf` written, X starts cleanly, sunshine captures the desktop.
- [x] Fresh install with mode 1 on a Spark with an HDMI dummy plug: same.
- [x] Fresh install with mode 2 on a truly headless Spark: identical to current installer behavior.
- [x] Re-run installer switching from headless to monitor: previous installer-managed `xorg.conf` is removed.
- [x] Re-run installer switching from monitor to headless: new `xorg.conf` is installed and validated.