### PR TITLE
Tune NVENC defaults: spatial AQ + qres multipass

### DIFF
--- a/templates/sunshine.conf.template
+++ b/templates/sunshine.conf.template
@@ -39,6 +39,8 @@ nvenc_preset = p7
 nvenc_tuning_info = lowlatency
 nvenc_vbv_increase = 0
 nvenc_rc = cbr
+nvenc_spatial_aq = 1
+nvenc_multipass = qres
 
 # Performance
 channels = 2


### PR DESCRIPTION
## Summary

Two NVENC quality knobs on top of #8's capture-path fix, verified on GB10:

- `nvenc_spatial_aq = 1` — Spatial Adaptive Quantization. Allocates more bits to detailed/high-frequency regions of each frame; subjectively sharper output on complex game scenes.
- `nvenc_multipass = qres` — Quarter-resolution multipass. Improves rate control under the existing `nvenc_rc = cbr` by doing a fast lookahead pass at 1/4 resolution before the final encode.

## Why

Both are low-cost, low-risk encoder tweaks aimed at the existing low-latency CBR profile this template already uses. They stack cleanly on top of #8 — same `[Video Encoding Settings]` block, no behavioral change to capture/output settings.

## Testing

Tested locally on GB10 NVENC at 2560x1440 @ 120Hz, 50 Mbps CBR, H.264 and HEVC:

- Subjective quality bump on detailed scenes (text/UI clarity, fine textures, motion compensation around camera pans)
- No measurable end-to-end latency regression in Moonlight (still 8-12 ms encode + network on LAN)
- No throughput degradation observed at 120 fps

## NVENC documentation references

- [NVIDIA Video Codec SDK — Spatial AQ](https://docs.nvidia.com/video-technologies/video-codec-sdk/13.0/nvenc-video-encoder-api-prog-guide/index.html#spatial-aq)
- [NVIDIA Video Codec SDK — Multi-pass encoding](https://docs.nvidia.com/video-technologies/video-codec-sdk/13.0/nvenc-video-encoder-api-prog-guide/index.html#multi-pass-encoding)
- Sunshine reads these via FFmpeg → NVENC; both knobs are exposed in upstream Sunshine config.

## Rollback

Either line can be removed independently. Setting `nvenc_spatial_aq = 0` or `nvenc_multipass = disabled` in the user's local `sunshine.conf` overrides the template default. No migration concerns.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated NVENC streaming encoder configuration with additional optimization parameters for spatial quality and multi-pass processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seanGSISG/dgx-spark-sunshine-setup/pull/11?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->