### PR TITLE
Fall back to pinned Sunshine .deb when GitHub API fails

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,6 +31,7 @@ readonly TEMPLATES_DIR="${SCRIPT_DIR}/templates"
 readonly BACKUP_DIR="${HOME}/.sunshine-setup-backups/$(date +%Y%m%d-%H%M%S)"
 
 readonly SUNSHINE_RELEASE_URL="https://api.github.com/repos/LizardByte/Sunshine/releases/latest"
+readonly SUNSHINE_FALLBACK_DEB="https://github.com/LizardByte/Sunshine/releases/download/v2025.924.154138/sunshine-ubuntu-24.04-arm64.deb"
 readonly SUNSHINE_CONFIG_DIR="${HOME}/.config/sunshine"
 readonly SYSTEMD_USER_DIR="${HOME}/.config/systemd/user"
 
@@ -536,30 +537,22 @@ install_sunshine() {
     fi
 
     log_substep "Fetching latest release information..."
-    local release_info http_code
-    # Fetch release info with error handling for both network and HTTP failures
-    if ! release_info=$(curl -sL --fail-with-body "${SUNSHINE_RELEASE_URL}"); then
-        log_error "Failed to fetch release info from GitHub (network error or rate-limited)"
-        log_substep "Check your internet connection or try again later"
-        exit 1
-    fi
-    if [[ -z "${release_info}" ]]; then
-        log_error "Empty response from GitHub API"
-        exit 1
-    fi
+    local release_info download_url
 
-    local download_url
-    # Specifically get Ubuntu 24.04 ARM64 package (not Debian Trixie which has library version mismatches)
-    download_url=$(echo "${release_info}" | grep -o "https://[^\"]*sunshine-ubuntu-24\.04-arm64\.deb" | head -1)
+    # Try GitHub API for latest release, fall back to pinned version on failure
+    if release_info=$(curl -sL --fail-with-body "${SUNSHINE_RELEASE_URL}" 2>/dev/null) && [[ -n "${release_info}" ]]; then
+        # Specifically get Ubuntu 24.04 ARM64 package (not Debian Trixie which has library version mismatches)
+        download_url=$(echo "${release_info}" | grep -o "https://[^\"]*sunshine-ubuntu-24\.04-arm64\.deb" | head -1)
 
-    # Fallback to any Ubuntu ARM64 package
-    if [[ -z "${download_url}" ]]; then
-        download_url=$(echo "${release_info}" | grep -o "https://[^\"]*sunshine-ubuntu.*arm64\.deb" | head -1)
+        # Fallback to any Ubuntu ARM64 package
+        if [[ -z "${download_url}" ]]; then
+            download_url=$(echo "${release_info}" | grep -o "https://[^\"]*sunshine-ubuntu.*arm64\.deb" | head -1)
+        fi
     fi
 
-    if [[ -z "${download_url}" ]]; then
-        log_error "Failed to find Ubuntu ARM64 .deb package in latest release"
-        exit 1
+    if [[ -z "${download_url:-}" ]]; then
+        log_warning "GitHub API unavailable or no ARM64 .deb found — using pinned fallback version"
+        download_url="${SUNSHINE_FALLBACK_DEB}"
     fi
 
     local deb_file


### PR DESCRIPTION
## Summary

The installer previously hard-exited on any GitHub API failure (network blip, rate-limit, transient outage), leaving users stuck on otherwise fully-prepared systems. This PR adds a pinned-version fallback so the install can still complete when the API is unreachable.

## Why

The original logic in `install_sunshine`:

```bash
if ! release_info=$(curl -sL --fail-with-body "${SUNSHINE_RELEASE_URL}"); then
    log_error "Failed to fetch release info from GitHub (network error or rate-limited)"
    log_substep "Check your internet connection or try again later"
    exit 1
fi
```

Hits the unauthenticated GitHub API rate limit easily — 60 requests/hour shared across the public IP. On a NATed network with multiple Sparks, a CI pipeline, or just bad timing, the installer aborts after every prerequisite has already passed.

## Behavior

Adds `SUNSHINE_FALLBACK_DEB` pinned to **v2025.924.154138** (last release I've personally verified on Ubuntu 24.04 ARM64 + GB10), then rewires `install_sunshine`:

| Condition | Behavior |
|---|---|
| API reachable + matching asset found | Use latest (unchanged from before) |
| API reachable, no matching asset | Warn + use pinned fallback |
| API unreachable / rate-limited | Warn + use pinned fallback |

Operators always see a `log_warning` when the fallback fires, so they know they're not on latest. Bumping the pin is a one-line change whenever a new release is verified.

## Why pinning is safe here

- Sunshine's release cadence is roughly quarterly; a pin that's a few weeks behind latest is fine in practice
- The `.deb` URL pattern is stable on the LizardByte release pipeline
- The only way the fallback URL goes 404 is if LizardByte deletes a past release asset, which they don't
- If the fallback URL does ever break, the failure mode is the same as today (hard exit with a clear error) — no regression

## Testing

- Manually `iptables -j REJECT` to `api.github.com` and re-ran installer → got the warning + fallback download path
- Tampered the `SUNSHINE_RELEASE_URL` to a 404 → same warning + fallback path
- Normal happy path with API reachable → unchanged behavior, uses latest

## Future maintenance

Worth adding to `.github/dependabot.yml` or a manual quarterly task: bump `SUNSHINE_FALLBACK_DEB` to whatever's currently `latest` after each LizardByte release that's verified on 24.04 ARM64.

## Rollback

Single-file change. Revert is a no-op (restores the hard-exit behavior).
