### PR TITLE
after-install: diagnose + auto-fix missing XAUTHORITY in systemd user env

### DIFF
--- a/after-install.sh
+++ b/after-install.sh
@@ -145,6 +145,28 @@ check_sunshine_service() {
         echo -e "${GRAY}  To enable: ${DIM}loginctl enable-linger $(whoami)${RESET}"
     fi
 
+    # Check XAUTHORITY in systemd user environment (required for screen capture)
+    local xauth_val
+    xauth_val=$(systemctl --user show-environment 2>/dev/null | grep '^XAUTHORITY=' | cut -d= -f2-)
+    if [[ -n "$xauth_val" ]]; then
+        log_success "XAUTHORITY set in systemd environment: ${DIM}${xauth_val}${RESET}"
+    else
+        log_warning "XAUTHORITY not set in systemd environment (Sunshine will capture a black screen)"
+        # Attempt auto-fix if we have a display
+        if [[ -n "${DISPLAY:-}" ]]; then
+            echo -e "${GRAY}  Attempting auto-fix...${RESET}"
+            if dbus-update-activation-environment --systemd DISPLAY XAUTHORITY 2>/dev/null; then
+                log_success "XAUTHORITY exported to systemd — restart Sunshine to apply"
+                echo -e "${GRAY}  Run: ${DIM}systemctl --user restart sunshine${RESET}"
+            else
+                log_error "Auto-fix failed"
+                echo -e "${GRAY}  Manual fix: ${DIM}dbus-update-activation-environment --systemd DISPLAY XAUTHORITY${RESET}"
+            fi
+        else
+            echo -e "${GRAY}  Run from a desktop terminal (not SSH): ${DIM}dbus-update-activation-environment --systemd DISPLAY XAUTHORITY${RESET}"
+        fi
+    fi
+
     echo ""
 
     if systemctl --user is-active sunshine &> /dev/null; then


### PR DESCRIPTION
## Why

Complementary to #9. That PR set up the install-time plumbing (`~/.xprofile` runs `dbus-update-activation-environment --systemd DISPLAY XAUTHORITY` on every X11 login) so the systemd-user environment learns the active X credentials. This PR catches the cases where that plumbing *didn't* fire and Sunshine ends up running with a missing `XAUTHORITY`:

- Wayland session — `~/.xprofile` was never sourced (already warned about in `configure_xprofile` after #9, but real installs in the wild may pre-date that warning).
- The user logged in before `~/.xprofile` was written, or `.xprofile` runs but a different login order leaves the systemd-user env stale.
- `sunshine.service` was enabled before linger + auto-login were configured in the same boot.

Symptom: Sunshine starts cleanly, Moonlight connects, and the captured stream is a black screen.

## What this changes

Single function modified in `after-install.sh` — `check_sunshine_service()` now:

1. Reads `systemctl --user show-environment | grep XAUTHORITY`.
2. **On success**: reports the path so the user knows the wiring is good (positive signal — `after-install` already prints a lot of green checks; this fits in).
3. **On failure with `$DISPLAY` set in the current shell**: auto-runs `dbus-update-activation-environment --systemd DISPLAY XAUTHORITY` and prompts a `systemctl --user restart sunshine`.
4. **On failure without `$DISPLAY`** (typical SSH path): prints the manual command the user should run from a graphical TTY.

22 lines added, no removals, no behaviour changes anywhere else in `after-install.sh`.

## Why it's defensive (not over-engineered)

- Read-only diagnostic by default; the auto-fix only fires when the shell is *already* an X11 session (`$DISPLAY` set), so it can't write the wrong creds into the user systemd env.
- No new dependencies — `systemctl --user show-environment` and `dbus-update-activation-environment` are both already required by #9.
- Cooperates with #9 cleanly: if `~/.xprofile` is already doing its job, this prints a one-line green confirmation and does nothing else.

## Test plan

Manual: on a Spark where `sunshine.service` is up but Moonlight captures a black screen, run `./after-install.sh`. Verify the diagnostic prints the corrected `XAUTHORITY` path and a `systemctl --user restart sunshine` brings the stream back without a logout.
